### PR TITLE
Dont use a null value when unable to parse variable

### DIFF
--- a/W3SavegameEditor.Core/Savegame/SavegameFile.cs
+++ b/W3SavegameEditor.Core/Savegame/SavegameFile.cs
@@ -130,11 +130,12 @@ namespace W3SavegameEditor.Core.Savegame
                 }
                 catch (ParseVariableException e)
                 {
-                    variables[i] = new InvalidVariable(e.Message);
+                    variables[i] = new InvalidVariable($"variable[{i}] - {e.Message}");
                     Debug.WriteLine(e.Message);
                 }
                 catch (Exception ex)
                 {
+                    variables[i] = new InvalidVariable($"variable[{i}] - {ex.Message}");
                     Debug.WriteLine(ex);
                 }
 

--- a/W3SavegameEditor.Core/Savegame/SavegameFile.cs
+++ b/W3SavegameEditor.Core/Savegame/SavegameFile.cs
@@ -130,6 +130,7 @@ namespace W3SavegameEditor.Core.Savegame
                 }
                 catch (ParseVariableException e)
                 {
+                    variables[i] = new InvalidVariable(e.Message);
                     Debug.WriteLine(e.Message);
                 }
                 catch (Exception ex)

--- a/W3SavegameEditor.Core/Savegame/VariableParser.cs
+++ b/W3SavegameEditor.Core/Savegame/VariableParser.cs
@@ -40,9 +40,8 @@ namespace W3SavegameEditor.Core.Savegame
         [DebuggerHidden]
         public Variable Parse(BinaryReader reader, ref int size)
         {
-            string magicNumber = reader.PeekString(2);
-            VariableParserBase parser;
-            if (_magicNumberToParserDictionary.TryGetValue(magicNumber, out parser))
+            if (_magicNumberToParserDictionary.TryGetValue(reader.PeekString(4), out var parser) ||
+                _magicNumberToParserDictionary.TryGetValue(reader.PeekString(2), out parser))
             {
                 parser.Verify(reader, ref size);
                 var variable = parser.Parse(reader, ref size);

--- a/W3SavegameEditor.Core/Savegame/VariableParsers/AvalVariableParser.cs
+++ b/W3SavegameEditor.Core/Savegame/VariableParsers/AvalVariableParser.cs
@@ -6,12 +6,7 @@ namespace W3SavegameEditor.Core.Savegame.VariableParsers
 {
     public class AvalVariableParser : VariableParserBase<AvalVariable>
     {
-        private const string FullMagicNumber = "AVAL";
-        
-        public override string MagicNumber
-        {
-            get { return "AV"; }
-        }
+        public override string MagicNumber => "AVAL";
 
         public override AvalVariable ParseImpl(BinaryReader reader, ref int size)
         {
@@ -32,22 +27,6 @@ namespace W3SavegameEditor.Core.Savegame.VariableParsers
                 Type = type,
                 Value = value
             };
-        }
-
-        public override void Verify(BinaryReader reader, ref int size)
-        {
-            var bytesToRead = FullMagicNumber.Length;
-            var magicNumber = reader.ReadString(bytesToRead);
-            if (magicNumber != FullMagicNumber)
-            {
-                throw new ParseVariableException(
-                    string.Format(
-                    "Expeced AVAL but read {0} at {1}",
-                    magicNumber,
-                    reader.BaseStream.Position - 4));
-            }
-
-            size -= bytesToRead;
         }
     }
 }

--- a/W3SavegameEditor.Core/Savegame/VariableParsers/BlckVariableParser.cs
+++ b/W3SavegameEditor.Core/Savegame/VariableParsers/BlckVariableParser.cs
@@ -7,8 +7,6 @@ namespace W3SavegameEditor.Core.Savegame.VariableParsers
 {
     public class BlckVariableParser : VariableParserBase<BlckVariable>
     {
-        private const string FullMagicNumber = "BLCK";
-
         private readonly VariableParser _parser;
         
         public BlckVariableParser(VariableParser parser)
@@ -16,10 +14,7 @@ namespace W3SavegameEditor.Core.Savegame.VariableParsers
             _parser = parser;
         }
 
-        public override string MagicNumber
-        {
-            get { return "BL"; }
-        }
+        public override string MagicNumber => "BLCK";
 
         public override BlckVariable ParseImpl(BinaryReader reader, ref int size)
         {
@@ -49,22 +44,6 @@ namespace W3SavegameEditor.Core.Savegame.VariableParsers
                 Name = name,
                 Variables = variables.ToArray()
             };
-        }
-
-        public override void Verify(BinaryReader reader, ref int size)
-        {
-            var bytesToRead = FullMagicNumber.Length;
-            var magicNumber = reader.ReadString(bytesToRead);
-            if (magicNumber != FullMagicNumber)
-            {
-                throw new ParseVariableException(
-                    string.Format(
-                    "Expeced BLCK but read {0} at {1}",
-                    magicNumber,
-                    reader.BaseStream.Position - 4));
-            }
-
-            size -= bytesToRead;
         }
     }
 }

--- a/W3SavegameEditor.Core/Savegame/VariableParsers/BsVariableParser.cs
+++ b/W3SavegameEditor.Core/Savegame/VariableParsers/BsVariableParser.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.IO;
+using W3SavegameEditor.Core.Exceptions;
 using W3SavegameEditor.Core.Savegame.Variables;
 
 namespace W3SavegameEditor.Core.Savegame.VariableParsers
@@ -16,9 +17,15 @@ namespace W3SavegameEditor.Core.Savegame.VariableParsers
             _parser = parser;
         }
 
-        public override string MagicNumber
+        public override string MagicNumber => "BS";
+
+        public override void Verify(BinaryReader reader, ref int size)
         {
-            get { return "BS"; }
+            base.Verify(reader, ref size);
+
+            const int expectedSize = sizeof(short);
+            if (size != expectedSize)
+                throw new ParseVariableException($"BSVariable: Expected to read {expectedSize} bytes but found {size} at {reader.BaseStream.Position}");
         }
 
         public override BsVariable ParseImpl(BinaryReader reader, ref int size)

--- a/W3SavegameEditor.Core/Savegame/VariableParsers/ManuVariableParser.cs
+++ b/W3SavegameEditor.Core/Savegame/VariableParsers/ManuVariableParser.cs
@@ -6,12 +6,7 @@ namespace W3SavegameEditor.Core.Savegame.VariableParsers
 {
     public class ManuVariableParser : VariableParserBase<ManuVariable>
     {
-        private const string FullMagicNumber = "MANU";
-
-        public override string MagicNumber
-        {
-            get { return "MA"; }
-        }
+        public override string MagicNumber => "MANU";
 
         public override ManuVariable ParseImpl(BinaryReader reader, ref int size)
         {
@@ -39,22 +34,6 @@ namespace W3SavegameEditor.Core.Savegame.VariableParsers
             {
                 Strings = strings
             };
-        }
-
-        public override void Verify(BinaryReader reader, ref int size)
-        {
-            var bytesToRead = FullMagicNumber.Length;
-            var magicNumber = reader.ReadString(bytesToRead);
-            if (magicNumber != FullMagicNumber)
-            {
-                throw new ParseVariableException(
-                    string.Format(
-                    "Expeced MANU but read {0} at {1}",
-                    magicNumber,
-                    reader.BaseStream.Position - 4));
-            }
-
-            size -= bytesToRead;
         }
     }
 }

--- a/W3SavegameEditor.Core/Savegame/VariableParsers/OpVariableParser.cs
+++ b/W3SavegameEditor.Core/Savegame/VariableParsers/OpVariableParser.cs
@@ -5,10 +5,7 @@ namespace W3SavegameEditor.Core.Savegame.VariableParsers
 {
     public class OpVariableParser : VariableParserBase<OpVariable>
     {
-        public override string MagicNumber
-        {
-            get { return "OP"; }
-        }
+        public override string MagicNumber => "OP";
 
         public override OpVariable ParseImpl(BinaryReader reader, ref int size)
         {

--- a/W3SavegameEditor.Core/Savegame/VariableParsers/PorpVariableParser.cs
+++ b/W3SavegameEditor.Core/Savegame/VariableParsers/PorpVariableParser.cs
@@ -7,12 +7,7 @@ namespace W3SavegameEditor.Core.Savegame.VariableParsers
 {
     public class PorpVariableParser : VariableParserBase<PorpVariable>
     {
-        private const string FullMagicNumber = "PORP";
-
-        public override string MagicNumber
-        {
-            get { return "PO"; }
-        }
+        public override string MagicNumber => "PORP";
 
         public override PorpVariable ParseImpl(BinaryReader reader, ref int size)
         {
@@ -38,22 +33,6 @@ namespace W3SavegameEditor.Core.Savegame.VariableParsers
                 Type = type,
                 Value = value
             };
-        }
-
-        public override void Verify(BinaryReader reader, ref int size)
-        {
-            var bytesToRead = FullMagicNumber.Length;
-            var magicNumber = reader.ReadString(bytesToRead);
-            if (magicNumber != FullMagicNumber)
-            {
-                throw new ParseVariableException(
-                    string.Format(
-                    "Expeced PORP but read {0} at {1}",
-                    magicNumber,
-                    reader.BaseStream.Position - 4));
-            }
-
-            size -= bytesToRead;
         }
     }
 }

--- a/W3SavegameEditor.Core/Savegame/VariableParsers/SsVariableParser.cs
+++ b/W3SavegameEditor.Core/Savegame/VariableParsers/SsVariableParser.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using W3SavegameEditor.Core.Exceptions;
 using W3SavegameEditor.Core.Savegame.Variables;
 
 namespace W3SavegameEditor.Core.Savegame.VariableParsers
@@ -14,9 +15,19 @@ namespace W3SavegameEditor.Core.Savegame.VariableParsers
             _parser = parser;
         }
 
-        public override string MagicNumber
+        public override string MagicNumber => "SS";
+
+        public override void Verify(BinaryReader reader, ref int size)
         {
-            get { return "SS"; }
+            base.Verify(reader, ref size);
+
+            var position = reader.BaseStream.Position;
+            var sizeInner = reader.ReadInt32();
+            reader.BaseStream.Position = position;
+            var expectedSize = sizeof(int) + sizeInner;
+
+            if (size != expectedSize)
+                throw new ParseVariableException($"SSVariable: Expected to read {expectedSize} bytes but found {size} at {reader.BaseStream.Position}");
         }
 
         public override SsVariable ParseImpl(BinaryReader reader, ref int size)

--- a/W3SavegameEditor.Core/Savegame/VariableParsers/SxapVariableParser.cs
+++ b/W3SavegameEditor.Core/Savegame/VariableParsers/SxapVariableParser.cs
@@ -6,13 +6,7 @@ namespace W3SavegameEditor.Core.Savegame.VariableParsers
 {
     public class SxapVariableParser : VariableParserBase<SxapVariable>
     {
-
-        private const string FullMagicNumber = "SXAP";
-
-        public override string MagicNumber
-        {
-            get { return "SX"; }
-        }
+        public override string MagicNumber => "SXAP";
 
         public override SxapVariable ParseImpl(BinaryReader reader, ref int size)
         {
@@ -27,22 +21,6 @@ namespace W3SavegameEditor.Core.Savegame.VariableParsers
                 TypeCode2 = typeCode2,
                 TypeCode3 = typeCode3
             };
-        }
-
-        public override void Verify(BinaryReader reader, ref int size)
-        {
-            var bytesToRead = FullMagicNumber.Length;
-            var magicNumber = reader.ReadString(bytesToRead);
-            if (magicNumber != FullMagicNumber)
-            {
-                throw new ParseVariableException(
-                    string.Format(
-                    "Expeced SXAP but read {0} at {1}",
-                    magicNumber,
-                    reader.BaseStream.Position - 4));
-            }
-
-            size -= bytesToRead;
         }
     }
 }

--- a/W3SavegameEditor.Core/Savegame/Variables/InvalidVariable.cs
+++ b/W3SavegameEditor.Core/Savegame/Variables/InvalidVariable.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace W3SavegameEditor.Core.Savegame.Variables
+{
+    public class InvalidVariable : Variable
+    {
+        private readonly string message;
+
+        public InvalidVariable(string message)
+        {
+            this.message = message;
+        }
+
+        public override string ToString()
+        {
+            return message;
+        }
+    }
+}

--- a/W3SavegameEditor.Core/Savegame/Variables/InvalidVariable.cs
+++ b/W3SavegameEditor.Core/Savegame/Variables/InvalidVariable.cs
@@ -1,7 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace W3SavegameEditor.Core.Savegame.Variables
 {
     public class InvalidVariable : Variable


### PR DESCRIPTION
So I ran into a save file that has a variable with the magic number `PO*P` instead of `PORP`. When the un-parsable exception is caught it never sets a value to the `variables` array which then causes a null reference exception in `SavegameFile.ReferenceVariable` when trying to access `nextVariable.TokenSize`.

I don't know if `PO*P` variables are supposed to be different from `PORP` variables or if falling back to `UnknownVariable` would be more preferable than the `InvalidVariable` I introduced. Let me know what you think.

[ManualSave_107631_7e400400_535c8ec.zip](https://github.com/Atvaark/W3SavegameEditor/files/4017934/ManualSave_107631_7e400400_535c8ec.zip)
